### PR TITLE
fix: make privKey, fingerprint and PSBT input origins public

### DIFF
--- a/LibWally/LibWally/BIP32.swift
+++ b/LibWally/LibWally/BIP32.swift
@@ -249,7 +249,7 @@ public struct HDKey {
         return PubKey(data, self.network, compressed: true)!
     }
     
-    var privKey: Key? {
+    public var privKey: Key? {
         if self.isNeutered {
             return nil
         }

--- a/LibWally/LibWally/PSBT.swift
+++ b/LibWally/LibWally/PSBT.swift
@@ -10,7 +10,7 @@ import Foundation
 import CLibWally
 
 public struct KeyOrigin : Equatable {
-    let fingerprint: Data
+    public let fingerprint: Data
     public let path: BIP32Path
 }
 
@@ -48,7 +48,7 @@ func getSignatures(signatures: wally_map, network: Network) -> [PubKey: Data] {
 
 public struct PSBTInput {
     let wally_psbt_input: wally_psbt_input
-    let origins: [PubKey: KeyOrigin]?
+    public let origins: [PubKey: KeyOrigin]?
     public let signatures: [PubKey: Data]?
 
     init(_ wally_psbt_input: wally_psbt_input, network: Network) {


### PR DESCRIPTION
This ensures anyone who uses this library will not get any errors when building Gordian apps from source.