### PR TITLE
Fix build script that causes error on some machines

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,7 @@ build_clibwally()
 
   cp ${PROJ_ROOT}/CLibWally.modulemap include/module.modulemap
 
+  ./tools/cleanup.sh
   ./tools/autogen.sh
   PKG_CONFIG_ALLOW_CROSS=1 \
   PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \


### PR DESCRIPTION
This PR fixes the build error that happens in some machines by adding small cleanup for each APU architecture building.